### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  # Javonet/combit
-Sample projects showing how to use combit List &amp; Label .NET component from Java throught strongly typed wrapped based on Javonet.
+Sample projects showing how to use combit List &amp; Label .NET component from Java through strongly typed wrapped based on Javonet.
 
 This example demonstrates the usage of the List & Label .NET component (https://www.combit.net/en/reporting-tool) in Java with 
 the third party component Javonet (https://www.javonet.com) and strongly-typed wrapper. Source code includes sample Swing desktop application using the component and compiled wrapper. Strongly-typed wrapper replicates List & Label 25 .NET API for Java, currently it exposes only the key operations required for this sample:


### PR DESCRIPTION
hey, just fixed a small typo:
throught > through
it needs to be fixed in the description of the repo too but I can't access that

happy hacktoberfest!